### PR TITLE
빌드타임 바이아웃 에러 해결

### DIFF
--- a/frontend/apps/contents/src/app/(afterLogin)/layout.tsx
+++ b/frontend/apps/contents/src/app/(afterLogin)/layout.tsx
@@ -1,9 +1,11 @@
 import "../globals.css";
 
+import { Suspense } from "react";
 import SystemModal from "@ui/components/Modal/SystemModal";
 import HeaderRoot from "@ui/components/Header/HeaderRoot";
 import RQProvider from "@ui/components/Provider/RQProvider";
 import NavigationRoot from "./_components/Navigation/NavigationRoot";
+import LoadingSpinner from "@ui/components/Spinner/FadeLoader";
 import styles from "./layout.module.css";
 
 export const metadata = {
@@ -41,10 +43,12 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={styles.layout}>
-        <HeaderRoot />
-        <RQProvider>{children}</RQProvider>
-        <NavigationRoot />
-        <SystemModal />
+        <Suspense fallback={<LoadingSpinner />}>
+          <HeaderRoot />
+          <RQProvider>{children}</RQProvider>
+          <NavigationRoot />
+          <SystemModal />
+        </Suspense>
       </body>
     </html>
   );

--- a/frontend/apps/contents/src/app/(beforeLogin)/layout.tsx
+++ b/frontend/apps/contents/src/app/(beforeLogin)/layout.tsx
@@ -1,4 +1,6 @@
+import { Suspense } from "react";
 import "../globals.css";
+import LoadingSpinner from "@ui/components/Spinner/FadeLoader";
 
 export const metadata = {
   title: "모임장",
@@ -37,8 +39,10 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body>
-        <RQProvider>{children}</RQProvider>
-        <SystemModal />
+        <Suspense fallback={<LoadingSpinner />}>
+          <RQProvider>{children}</RQProvider>
+          <SystemModal />
+        </Suspense>
       </body>
     </html>
   );

--- a/frontend/apps/seller/src/app/layout.tsx
+++ b/frontend/apps/seller/src/app/layout.tsx
@@ -2,6 +2,8 @@ import "./globals.css";
 import RQProvider from "@ui/components/Provider/RQProvider";
 import HeaderRoot from "@ui/components/Header/HeaderRoot";
 import SystemModal from "@ui/components/Modal/SystemModal";
+import LoadingSpinner from "@ui/components/Spinner/FadeLoader";
+import { Suspense } from "react";
 
 export const metadata = {
   title: "모임장",
@@ -38,9 +40,11 @@ export default async function RootLayout({
   return (
     <html lang="ko">
       <body>
-        <HeaderRoot />
-        <RQProvider>{children}</RQProvider>
-        <SystemModal />
+        <Suspense fallback={<LoadingSpinner />}>
+          <HeaderRoot />
+          <RQProvider>{children}</RQProvider>
+          <SystemModal />
+        </Suspense>
       </body>
     </html>
   );


### PR DESCRIPTION
⨯ useSearchParams() should be wrapped in a suspense boundary at page 에러 발생
### 원인
•page 컴포넌트는 기본적으로 서버 컴포넌트(RSC)이고 그 안에 있는 <Card /> 는 "use client" 선언으로 클라이언트 컴포넌트(CC)입니다.
•클라이언트 훅(useSearchParams, useParams 등)을 만나면 RSC가 CSR로 “바이아웃(bailout)” 되는데, 이때 React의 비동기 경계인 Suspense 로 감싸지 않으면 Next.js가 컴파일 단계에서 위 에러를 띄웁니다.

### 해결
app/layout.tsx 레벨에서 전역으로 <Suspense>를 한 번만 걸어두셔도, 모든 자식 라우트에 적용되므로 레이아웃에 적용함